### PR TITLE
HTTP reconnect bug fix

### DIFF
--- a/src/core/https_socket.c
+++ b/src/core/https_socket.c
@@ -100,7 +100,9 @@ static int https_reconnect(struct https_socket* sock){
     SSL_shutdown(sock->ssl);
     SSL_free(sock->ssl);
     close(sock->socket_fd);
-    if(https_tcp_connect(sock, sock->hostname, sock->port)){
+    char* old_hostname = sock->hostname;
+    char* old_port = sock->port;
+    if(https_tcp_connect(sock, old_hostname, old_port)){
         fputs("Failed to reconnect TCP socket\n", stderr);
         return 1;
     }
@@ -108,6 +110,8 @@ static int https_reconnect(struct https_socket* sock){
         fputs("Failed to reconnect TLS socket\n", stderr);
         return 1;
     }
+    free(old_hostname);
+    free(old_port);
     return 0;
 }
 
@@ -277,6 +281,7 @@ char* https_send(struct https_socket* sock, const char* data){
             fputs("Failed to send request after reconnecting\n", stderr);
             return NULL;
         }
+        fputs("Reconnected successfully\n", stderr);
     }
     
     char buffer[64 * 8192];

--- a/src/core/https_socket.c
+++ b/src/core/https_socket.c
@@ -288,7 +288,11 @@ char* https_send(struct https_socket* sock, const char* data){
     size_t buffer_size = 0;
     char* header_end = https_read_headers(sock->ssl, buffer, &buffer_size, sizeof(buffer));
     if(header_end == NULL){
-        fputs("Connection may be stale, attempting to reconnect\n", stderr);
+        char byte;
+        int peek_ret = recv(sock->socket_fd, &byte, 1, MSG_PEEK | MSG_DONTWAIT);
+        if(peek_ret > 0)
+            return NULL;
+        fputs("Connection is stale, attempting to reconnect\n", stderr);
         buffer_size = 0;
         if(https_reconnect(sock)){
             fputs("Reconnection failed\n", stderr);


### PR DESCRIPTION
Potential stale connections result in reconnect logic for writing to not trip, resulting in the following header read to fail. Added reconnect logic for failed header reads to account for this. The immediate effect for the bot should be the bot no longer appears to ignore commands.
Closes #5 