### PR TITLE
Improved help messages

### DIFF
--- a/include/bot/help.h
+++ b/include/bot/help.h
@@ -1,0 +1,12 @@
+#ifndef HELP_H
+#define HELP_H
+
+#include "core/discord.h"
+
+char* help_command(struct discord_bot* bot, const char* channel_id);
+
+char* help_helldivers(struct discord_bot* bot, const char* channel_id);
+
+char* help_info(struct discord_bot* bot, const char* channel_id);
+
+#endif

--- a/include/core/discord.h
+++ b/include/core/discord.h
@@ -51,6 +51,8 @@ struct discord_event{
 
 int discord_init(struct discord_bot* bot);
 
+char* discord_send_raw(struct discord_bot* bot, const char* channel_id, const char* raw_json);
+
 char* discord_send_message(struct discord_bot* bot, const char* channel, const char* content);
 
 char* discord_send_embed(struct discord_bot* bot, const char* channel, const char* title, const char* description, const int color_hex);

--- a/src/bot/commands.c
+++ b/src/bot/commands.c
@@ -1,5 +1,6 @@
 #include "bot/commands.h"
 #include "bot/helldivers.h"
+#include "bot/help.h"
 
 enum command_hashes{
     CMD_SELL = 2090720021, CMD_BUDDY = 254689437, CMD_SOLD = 2090730903,
@@ -13,20 +14,23 @@ enum command_hashes{
     CMD_DIVE = 2090185645//dive is not implemented yet
 };
 
-static int djb2_hash(const char* command){
+static int djb2_hash(const char* command, const char** args){
     int hash = 5381;
     int c;
     while((c = *command++)){
-        if(c == ' ')
+        if(c == ' '){
+            *args = command;
             break;
+        }
         hash = ((hash << 5) + hash) + c;
     }
     return hash;
 }
 
 int handle_command(struct discord_bot* bot, const char* channel_id, const char* content){
+    const char* args = NULL;
     content++;//skip '!' prefix
-    int hash = djb2_hash(content);
+    int hash = djb2_hash(content, &args);
 
     char* response = NULL;
     switch(hash){
@@ -75,7 +79,12 @@ int handle_command(struct discord_bot* bot, const char* channel_id, const char* 
             response = discord_send_message(bot, channel_id, "https://github.com/nolanflores/discord-bot-rpi-c");
             break;
         case CMD_HELP:
-            response = discord_send_embed(bot, channel_id, "Available Commands", "!sell\\n!buddy\\n!sold\\n!bust\\n!slap\\n!react\\n!pray\\n!whip\\n!tap\\n!nuke\\n!notice\\n!winner\\n!mo\\n!war\\n!version\\n!repo", 0x192930);
+            if(args == NULL)
+                response = help_command(bot, channel_id);
+            else if(strcmp(args, "hd2") == 0)
+                response = help_helldivers(bot, channel_id);
+            else if(strcmp(args, "info") == 0)
+                response = help_info(bot, channel_id);
             break;
         //Commands with https requests
         case CMD_MO:

--- a/src/bot/help.c
+++ b/src/bot/help.c
@@ -1,0 +1,71 @@
+#include "bot/help.h"
+
+char* help_command(struct discord_bot* bot, const char* channel_id){
+    char *help_payload = "{"
+        "\"embeds\": [{"
+            "\"title\": \"Command Help\","
+            "\"description\": \"Use `!help <category>` for more info\","
+            "\"color\": 3894651,"
+            "\"fields\": ["
+                "{"
+                    "\"name\": \"GIFs\","
+                    "\"value\": \"`!sell` `!buddy` `!sold` `!bust` `!slap` `!react` `!pray` `!whip` `!tap` `!nuke` `!notice` `!winner`\","
+                    "\"inline\": false"
+                "},{"
+                    "\"name\": \"Helldivers 2\","
+                    "\"value\": \"`!mo` `!war`\","
+                    "\"inline\": false"
+                "},{"
+                    "\"name\": \"Bot Info\","
+                    "\"value\": \"`!version` `!repo`\","
+                    "\"inline\": false"
+                "}"
+            "],"
+            "\"footer\": {\"text\": \"!help hd2 - !help info\"}"
+        "}]"
+    "}";
+    return discord_send_raw(bot, channel_id, help_payload);
+}
+
+char* help_helldivers(struct discord_bot* bot, const char* channel_id){
+    char *help_hd2_payload = "{"
+        "\"embeds\": [{"
+            "\"title\": \"Helldivers 2\","
+            "\"color\": 3894651,"
+            "\"fields\": ["
+                "{"
+                    "\"name\": \"`!mo`\","
+                    "\"value\": \"Displays the currently active Major Orders\","
+                    "\"inline\": false"
+                "},{"
+                    "\"name\": \"`!war`\","
+                    "\"value\": \"Displays the current state of the galactic war\","
+                    "\"inline\": false"
+                "}"
+            "],"
+            "\"footer\": {\"text\": \"Data pulled live from the Helldivers 2 API\"}"
+        "}]"
+    "}";
+    return discord_send_raw(bot, channel_id, help_hd2_payload);
+}
+
+char* help_info(struct discord_bot* bot, const char* channel_id){
+    char *help_info_payload = "{"
+        "\"embeds\": [{"
+            "\"title\": \"Bot Info\","
+            "\"color\": 3894651,"
+            "\"fields\": ["
+                "{"
+                    "\"name\": \"`!version`\","
+                    "\"value\": \"Prints the version of C the bot was compiled with\","
+                    "\"inline\": false"
+                "},{"
+                    "\"name\": \"`!repo`\","
+                    "\"value\": \"Links to the bot's source code repository\","
+                    "\"inline\": false"
+                "}"
+            "]"
+        "}]"
+    "}";
+    return discord_send_raw(bot, channel_id, help_info_payload);
+}

--- a/src/core/discord.c
+++ b/src/core/discord.c
@@ -182,41 +182,7 @@ void discord_free_event(struct discord_event* event){
 
 
 
-static char* discord_send(struct discord_bot* bot, const char* request){
-    char* response = https_send(&bot->rest_api, request);
-    return response;
-}
-
-
-
-char* discord_send_message(struct discord_bot* bot, const char* channel_id, const char* content){
-    char request[8192];
-    snprintf(request, 8192,
-        "POST /api/v10/channels/%s/messages HTTP/1.1\r\n"
-        "Host: discord.com\r\n"
-        "Authorization: %s\r\n"
-        "Content-Type: application/json\r\n"
-        "Content-Length: %zu\r\n"
-        "\r\n"
-        "{\"content\":\"%s\"}",
-        channel_id,
-        DISCORD_TOKEN,
-        strlen(content) + 14,
-        content
-    );
-    return discord_send(bot, request);
-}
-
-
-
-char* discord_send_embed(struct discord_bot* bot, const char* channel_id, const char* title, const char* description, const int color_hex){
-    char content[6144];
-    size_t content_length = snprintf(content, 6144,
-        "{\"embeds\":[{\"title\":\"%s\",\"description\":\"%s\",\"color\":%d}]}",
-        title,
-        description,
-        color_hex
-    );
+char* discord_send_raw(struct discord_bot* bot, const char* channel_id, const char* raw_json){
     char request[8192];
     snprintf(request, 8192,
         "POST /api/v10/channels/%s/messages HTTP/1.1\r\n"
@@ -227,10 +193,31 @@ char* discord_send_embed(struct discord_bot* bot, const char* channel_id, const 
         "\r\n%s",
         channel_id,
         DISCORD_TOKEN,
-        content_length,
-        content
+        strlen(raw_json),
+        raw_json
     );
-    return discord_send(bot, request);
+    return https_send(&bot->rest_api, request);
+}
+
+
+
+char* discord_send_message(struct discord_bot* bot, const char* channel_id, const char* content){
+    char request[6144];
+    snprintf(request, 6144,"{\"content\":\"%s\"}", content);
+    return discord_send_raw(bot, channel_id, request);
+}
+
+
+
+char* discord_send_embed(struct discord_bot* bot, const char* channel_id, const char* title, const char* description, const int color_hex){
+    char request[6144];
+    snprintf(request, 6144,
+        "{\"embeds\":[{\"title\":\"%s\",\"description\":\"%s\",\"color\":%d}]}",
+        title,
+        description,
+        color_hex
+    );
+    return discord_send_raw(bot, channel_id, request);
 }
 
 


### PR DESCRIPTION
I reworked the discord send functions, creating a new discord_send_raw, which just sends the raw json passed to it. This also allowed me to rewrite the generic discord_send_message and discord_send_embed to just format a request string and then pass it to send_raw.

I used these changes to create more complex embed messages for the help command.